### PR TITLE
Changing searchArticles() to return based on date

### DIFF
--- a/lib/newsquery.js
+++ b/lib/newsquery.js
@@ -453,7 +453,7 @@ module.exports = (function(apiKey, cacheEnabled, cacheOptions) {
         if (cacheValue !== false)
             return cacheValue;
 
-        var url = this.juicerApiHost+"/articles.json?content_format[]=TextualFormat&text="+encodeURIComponent(keywords)+'&apikey='+encodeURIComponent(this.apiKey);
+        var url = this.juicerApiHost+"/articles.json?content_format[]=TextualFormat&recent_first=yes&text="+encodeURIComponent(keywords)+'&apikey='+encodeURIComponent(this.apiKey);
 
         if (publishedAfter)
             url += "&published_after="+publishedAfter;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "name": "newsquery",
   "description": "The newsQuery NPM package provides a library to interact with the BBC News Labs Juicer",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "./lib/newsquery.js",
   "keywords": [
     "newsQuery",


### PR DESCRIPTION
Currently it was (incorrectly) returning based on "best match" for the provided search terms.

It's now returning based on latest news first, which was the intended default behaviour.

I'd like to make this an option in future.
